### PR TITLE
Issue 1  control parameters.to reversed is not a function

### DIFF
--- a/logic/scripter/CCRider/CCRider.js
+++ b/logic/scripter/CCRider/CCRider.js
@@ -157,7 +157,7 @@ function main() {
     }
   }
 
-  const VERSION = "1.0";
+  const VERSION = "1.0.1";
   var startupMessage = `---\nCCRider ${VERSION} (@2023 Michael Bishop)\n\nInstructions: https://github.com/michaeljbishop/music-production/logic/scripter/CCRider/README.md\n     License: https://github.com/michaeljbishop/music-production/README.md\n---`;
   if (kUseTargetPararmeters) {
     startupMessage += (`\nWARNING: kUseTargetPararmeters = ${kUseTargetPararmeters}. Direct plugin parameters on VST Instruments may be reset when Core Audio is reset.\n---`);

--- a/logic/scripter/CCRider/CCRider.js
+++ b/logic/scripter/CCRider/CCRider.js
@@ -422,7 +422,9 @@ function CCRider(key, defaultParameterCount, defaultCCOutput) {
 
   Object.defineProperty(this, "parameters", {
     get() {
-      return [_outputParameter].concat(_controlParameters.toReversed());
+      var reversedControlParameters = _controlParameters.slice();
+      reversedControlParameters.reverse();
+      return [_outputParameter].concat(reversedControlParameters);
     }
   });
 


### PR DESCRIPTION
Fixes issue where `Array.toReversed` didn't work in older versions of Logic. This is replaced with `Array.slice()` + `Array.reverse()`.